### PR TITLE
perf: test section component

### DIFF
--- a/apps/monogram/app/layout.tsx
+++ b/apps/monogram/app/layout.tsx
@@ -1,8 +1,13 @@
 import "@monogram/ui/styles/global.css";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
+import React from "react";
 
 const inter = Inter({ subsets: ["latin"] });
+
+const SCROLL_TIMELINE_POLYFILL =
+  "https://flackr.github.io/scroll-timeline/dist/scroll-timeline.js";
 
 export const metadata: Metadata = {
   title: "Monogram frontend test",
@@ -16,6 +21,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <Script src={SCROLL_TIMELINE_POLYFILL} />
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -6,7 +6,6 @@ import {
   BlocksSection,
   SquigglyDivider,
   Heading,
-  // Footer,
   // Sphere,
 } from "@monogram/ui";
 import React from "react";
@@ -14,7 +13,7 @@ import React from "react";
 import {
   TOP_CONTENT_SECTION,
   BOTTOM_CONTENT_SECTION,
-  // PRESENTATION_SECTION,
+  PRESENTATION_SECTION,
   COMPUTER_SECTION,
   FOOTER_PROPS,
 } from "@/fixtures";
@@ -45,16 +44,16 @@ function LogosSection() {
   );
 }
 
-// function PresentationSection() {
-//   return (
-//     <section className="bg-[#151515] padded -mb-px">
-//       <div className="mx-auto max-w-7xl">
-//         <Heading {...PRESENTATION_SECTION} />
-//         <ThreeJSSphere />
-//       </div>
-//     </section>
-//   );
-// }
+function PresentationSection() {
+  return (
+    <section className="bg-[#151515] padded -mb-px">
+      <div className="mx-auto max-w-7xl">
+        <Heading {...PRESENTATION_SECTION} />
+        {/*<ThreeJSSphere />*/}
+      </div>
+    </section>
+  );
+}
 
 function HeaderSection() {
   return <ContentSection {...TOP_CONTENT_SECTION} className="md:mt-40" />;
@@ -65,7 +64,7 @@ function MainContent() {
     <>
       <ComputerSection {...COMPUTER_SECTION} />
       <LogosSection />
-      {/*<PresentationSection />*/}
+      <PresentationSection />
       <SquigglyDivider />
     </>
   );

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -5,7 +5,7 @@ import {
   BlocksSection,
   SquigglyDivider,
   // Heading,
-  // Footer,
+  Footer,
   // Sphere,
 } from "@monogram/ui";
 import React from "react";
@@ -15,7 +15,7 @@ import {
   BOTTOM_CONTENT_SECTION,
   // PRESENTATION_SECTION,
   COMPUTER_SECTION,
-  // FOOTER_PROPS,
+  FOOTER_PROPS,
 } from "@/fixtures";
 
 // function ThreeJSSphere() {
@@ -78,7 +78,7 @@ export default function Home() {
       <MainContent />
       <BottomSection />
       <BlocksSection />
-      {/*<Footer {...FOOTER_PROPS} />*/}
+      <Footer {...FOOTER_PROPS} />
     </main>
   );
 }

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -1,12 +1,11 @@
 import dynamic from "next/dynamic";
 
 import {
-  // LogosGrid,
   ContentSection,
   ComputerSection,
   BlocksSection,
   SquigglyDivider,
-  // Heading,
+  Heading,
   // Footer,
   // Sphere,
 } from "@monogram/ui";
@@ -20,6 +19,10 @@ import {
   FOOTER_PROPS,
 } from "@/fixtures";
 
+const DynamicScoreGrid = dynamic(
+  () => import("@monogram/ui/src/components/animated/logos/LogosGrid")
+);
+
 const DynamicFooter = dynamic(() =>
   import("@monogram/ui/src/slices/footer/Footer").then((mod) => mod.Footer)
 );
@@ -32,15 +35,15 @@ const DynamicFooter = dynamic(() =>
 //   );
 // }
 
-// function LogosSection() {
-//   return (
-//     <section className="bg-[#151515] relative padded">
-//       <div className="container">
-//         <LogosGrid />
-//       </div>
-//     </section>
-//   );
-// }
+function LogosSection() {
+  return (
+    <section className="bg-[#151515] relative padded">
+      <div className="container">
+        <DynamicScoreGrid />
+      </div>
+    </section>
+  );
+}
 
 // function PresentationSection() {
 //   return (
@@ -61,7 +64,7 @@ function MainContent() {
   return (
     <>
       <ComputerSection {...COMPUTER_SECTION} />
-      {/*<LogosSection />*/}
+      <LogosSection />
       {/*<PresentationSection />*/}
       <SquigglyDivider />
     </>

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -2,7 +2,7 @@ import {
   // LogosGrid,
   ContentSection,
   // ComputerSection,
-  // BlocksSection,
+  BlocksSection,
   // SquigglyDivider,
   // Heading,
   // Footer,
@@ -77,7 +77,7 @@ export default function Home() {
       <HeaderSection />
       {/*<MainContent />*/}
       <BottomSection />
-      {/*<BlocksSection />*/}
+      <BlocksSection />
       {/*<Footer {...FOOTER_PROPS} />*/}
     </main>
   );

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -1,3 +1,5 @@
+import dynamic from "next/dynamic";
+
 import {
   // LogosGrid,
   ContentSection,
@@ -5,7 +7,7 @@ import {
   BlocksSection,
   SquigglyDivider,
   // Heading,
-  Footer,
+  // Footer,
   // Sphere,
 } from "@monogram/ui";
 import React from "react";
@@ -17,6 +19,10 @@ import {
   COMPUTER_SECTION,
   FOOTER_PROPS,
 } from "@/fixtures";
+
+const DynamicFooter = dynamic(() =>
+  import("@monogram/ui/src/slices/footer/Footer").then((mod) => mod.Footer)
+);
 
 // function ThreeJSSphere() {
 //   return (
@@ -78,7 +84,7 @@ export default function Home() {
       <MainContent />
       <BottomSection />
       <BlocksSection />
-      <Footer {...FOOTER_PROPS} />
+      <DynamicFooter {...FOOTER_PROPS} />
     </main>
   );
 }

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -3,7 +3,7 @@ import {
   ContentSection,
   // ComputerSection,
   BlocksSection,
-  // SquigglyDivider,
+  SquigglyDivider,
   // Heading,
   // Footer,
   // Sphere,
@@ -51,16 +51,16 @@ function HeaderSection() {
   return <ContentSection {...TOP_CONTENT_SECTION} className="md:mt-40" />;
 }
 
-// function MainContent() {
-//   return (
-//     <>
-//       <ComputerSection {...COMPUTER_SECTION} />
-//       <LogosSection />
-//       <PresentationSection />
-//       <SquigglyDivider />
-//     </>
-//   );
-// }
+function MainContent() {
+  return (
+    <>
+      {/*<ComputerSection {...COMPUTER_SECTION} />*/}
+      {/*<LogosSection />*/}
+      {/*<PresentationSection />*/}
+      <SquigglyDivider />
+    </>
+  );
+}
 
 function BottomSection() {
   return (
@@ -75,7 +75,7 @@ export default function Home() {
   return (
     <main className="flex flex-col overflow-hidden min-h-[100svh]">
       <HeaderSection />
-      {/*<MainContent />*/}
+      <MainContent />
       <BottomSection />
       <BlocksSection />
       {/*<Footer {...FOOTER_PROPS} />*/}

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -1,66 +1,66 @@
 import {
-  LogosGrid,
+  // LogosGrid,
   ContentSection,
-  ComputerSection,
-  BlocksSection,
-  SquigglyDivider,
-  Heading,
-  Footer,
-  Sphere,
+  // ComputerSection,
+  // BlocksSection,
+  // SquigglyDivider,
+  // Heading,
+  // Footer,
+  // Sphere,
 } from "@monogram/ui";
 import React from "react";
 
 import {
   TOP_CONTENT_SECTION,
   BOTTOM_CONTENT_SECTION,
-  PRESENTATION_SECTION,
-  COMPUTER_SECTION,
-  FOOTER_PROPS,
+  // PRESENTATION_SECTION,
+  // COMPUTER_SECTION,
+  // FOOTER_PROPS,
 } from "@/fixtures";
 
-function ThreeJSSphere() {
-  return (
-    <div className="relative z-40 mx-auto mt-16 aspect-square max-w-[70%] -mb-[50%] lg:mt-32">
-      <Sphere />
-    </div>
-  );
-}
+// function ThreeJSSphere() {
+//   return (
+//     <div className="relative z-40 mx-auto mt-16 aspect-square max-w-[70%] -mb-[50%] lg:mt-32">
+//       <Sphere />
+//     </div>
+//   );
+// }
 
-function LogosSection() {
-  return (
-    <section className="bg-[#151515] relative padded">
-      <div className="container">
-        <LogosGrid />
-      </div>
-    </section>
-  );
-}
+// function LogosSection() {
+//   return (
+//     <section className="bg-[#151515] relative padded">
+//       <div className="container">
+//         <LogosGrid />
+//       </div>
+//     </section>
+//   );
+// }
 
-function PresentationSection() {
-  return (
-    <section className="bg-[#151515] padded -mb-px">
-      <div className="mx-auto max-w-7xl">
-        <Heading {...PRESENTATION_SECTION} />
-        <ThreeJSSphere />
-      </div>
-    </section>
-  );
-}
+// function PresentationSection() {
+//   return (
+//     <section className="bg-[#151515] padded -mb-px">
+//       <div className="mx-auto max-w-7xl">
+//         <Heading {...PRESENTATION_SECTION} />
+//         <ThreeJSSphere />
+//       </div>
+//     </section>
+//   );
+// }
 
 function HeaderSection() {
   return <ContentSection {...TOP_CONTENT_SECTION} className="md:mt-40" />;
 }
 
-function MainContent() {
-  return (
-    <>
-      <ComputerSection {...COMPUTER_SECTION} />
-      <LogosSection />
-      <PresentationSection />
-      <SquigglyDivider />
-    </>
-  );
-}
+// function MainContent() {
+//   return (
+//     <>
+//       <ComputerSection {...COMPUTER_SECTION} />
+//       <LogosSection />
+//       <PresentationSection />
+//       <SquigglyDivider />
+//     </>
+//   );
+// }
 
 function BottomSection() {
   return (
@@ -75,10 +75,10 @@ export default function Home() {
   return (
     <main className="flex flex-col overflow-hidden min-h-[100svh]">
       <HeaderSection />
-      <MainContent />
+      {/*<MainContent />*/}
       <BottomSection />
-      <BlocksSection />
-      <Footer {...FOOTER_PROPS} />
+      {/*<BlocksSection />*/}
+      {/*<Footer {...FOOTER_PROPS} />*/}
     </main>
   );
 }

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -22,17 +22,21 @@ const DynamicScoreGrid = dynamic(
   () => import("@monogram/ui/src/components/animated/logos/LogosGrid")
 );
 
+const DynamicThreeJSSphere = dynamic(
+  () => import("@monogram/ui/src/components/animated/3d/Sphere")
+);
+
 const DynamicFooter = dynamic(() =>
   import("@monogram/ui/src/slices/footer/Footer").then((mod) => mod.Footer)
 );
 
-// function ThreeJSSphere() {
-//   return (
-//     <div className="relative z-40 mx-auto mt-16 aspect-square max-w-[70%] -mb-[50%] lg:mt-32">
-//       <Sphere />
-//     </div>
-//   );
-// }
+function ThreeJSSphere() {
+  return (
+    <div className="relative z-40 mx-auto mt-16 aspect-square max-w-[70%] -mb-[50%] lg:mt-32">
+      <DynamicThreeJSSphere />
+    </div>
+  );
+}
 
 function LogosSection() {
   return (

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -6,7 +6,6 @@ import {
   BlocksSection,
   SquigglyDivider,
   Heading,
-  // Sphere,
 } from "@monogram/ui";
 import React from "react";
 
@@ -53,7 +52,7 @@ function PresentationSection() {
     <section className="bg-[#151515] padded -mb-px">
       <div className="mx-auto max-w-7xl">
         <Heading {...PRESENTATION_SECTION} />
-        {/*<ThreeJSSphere />*/}
+        <ThreeJSSphere />
       </div>
     </section>
   );

--- a/apps/monogram/app/page.tsx
+++ b/apps/monogram/app/page.tsx
@@ -1,7 +1,7 @@
 import {
   // LogosGrid,
   ContentSection,
-  // ComputerSection,
+  ComputerSection,
   BlocksSection,
   SquigglyDivider,
   // Heading,
@@ -14,7 +14,7 @@ import {
   TOP_CONTENT_SECTION,
   BOTTOM_CONTENT_SECTION,
   // PRESENTATION_SECTION,
-  // COMPUTER_SECTION,
+  COMPUTER_SECTION,
   // FOOTER_PROPS,
 } from "@/fixtures";
 
@@ -54,7 +54,7 @@ function HeaderSection() {
 function MainContent() {
   return (
     <>
-      {/*<ComputerSection {...COMPUTER_SECTION} />*/}
+      <ComputerSection {...COMPUTER_SECTION} />
       {/*<LogosSection />*/}
       {/*<PresentationSection />*/}
       <SquigglyDivider />

--- a/apps/monogram/next.config.js
+++ b/apps/monogram/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["monogram-ui"],
+  transpilePackages: ["three, monogram-ui"],
   images: {
     domains: ["cdn.raster.app"],
   },

--- a/packages/monogram-ui/package.json
+++ b/packages/monogram-ui/package.json
@@ -46,6 +46,7 @@
     "next": "^13.4.12",
     "react-device-detect": "^2.2.3",
     "react-error-boundary": "^3.1.4",
+    "react-intersection-observer": "^9.5.2",
     "three": "^0.155.0",
     "utils": "workspace:*"
   },

--- a/packages/monogram-ui/src/components/animated/3d/Sphere.tsx
+++ b/packages/monogram-ui/src/components/animated/3d/Sphere.tsx
@@ -47,7 +47,11 @@ function SphereObject() {
 }
 
 export const Sphere = () => {
-  const { ref, inView } = useInView({ threshold: 0 });
+  const { ref, inView } = useInView({
+    threshold: 0,
+    triggerOnce: true,
+    rootMargin: "0px 0px 100% 0px",
+  });
 
   return (
     <div ref={ref} className="h-full">

--- a/packages/monogram-ui/src/components/animated/3d/Sphere.tsx
+++ b/packages/monogram-ui/src/components/animated/3d/Sphere.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-// Don't include THREE in the bundle and use @react-three instead if possible.
 import React, { useRef } from "react";
-import { Canvas, useFrame, type MeshProps } from "@react-three/fiber";
+import { useInView } from "react-intersection-observer";
+import { Canvas, useFrame } from "@react-three/fiber";
 import {
   MeshDistortMaterial,
   GradientTexture,
@@ -14,12 +14,9 @@ import {
 function SphereObject() {
   const meshRef = useRef<any>(null);
 
-  // use useFrame hook to get performant animations (instead of doing it with react hooks)
   useFrame((state) => {
     if (meshRef.current) {
-      const material = meshRef.current.material as MeshProps & {
-        distort?: number;
-      };
+      const material = meshRef.current.material as any;
       const elapsedTime = state.clock.getElapsedTime();
       material.distort = (1 + Math.sin(elapsedTime * 0.5)) * 0.15;
     }
@@ -29,8 +26,8 @@ function SphereObject() {
     <Center>
       <mesh
         ref={meshRef}
-        onPointerOver={() => ((meshRef.current?.material as any).distort = 0.3)} // manipulate the object directly to avoid additional state management
-        onPointerOut={() => ((meshRef.current?.material as any).distort = 0)}
+        onPointerOver={() => (meshRef.current.material.distort = 0.3)}
+        onPointerOut={() => (meshRef.current.material.distort = 0)}
       >
         <sphereGeometry args={[0.75, 64, 64]} />
         <MeshDistortMaterial speed={3} roughness={1}>
@@ -50,19 +47,26 @@ function SphereObject() {
 }
 
 export const Sphere = () => {
+  const { ref, inView } = useInView({ threshold: 0 });
+
   return (
-    <Canvas shadows camera={{ position: [0, 0, 2], fov: 50 }}>
-      <SphereObject />
-      <OrbitControls
-        autoRotate
-        autoRotateSpeed={4}
-        enablePan={false}
-        enableZoom={false}
-        minPolarAngle={Math.PI / 2.1}
-        maxPolarAngle={Math.PI / 2.1}
-      />
-      <Environment blur={1} preset={"warehouse"} />
-    </Canvas>
+    <div ref={ref} className="h-full">
+      {inView && (
+        <Canvas shadows camera={{ position: [0, 0, 2], fov: 50 }}>
+          <SphereObject />
+          <OrbitControls
+            autoRotate
+            autoRotateSpeed={4}
+            enablePan={false}
+            enableZoom={false}
+            minZoom={2}
+            minPolarAngle={Math.PI / 2.1}
+            maxPolarAngle={Math.PI / 2.1}
+          />
+          <Environment blur={1} preset={"warehouse"} />
+        </Canvas>
+      )}
+    </div>
   );
 };
 

--- a/packages/monogram-ui/src/components/animated/logos/LogosGrid.tsx
+++ b/packages/monogram-ui/src/components/animated/logos/LogosGrid.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useRef } from "react";
 
 import Image from "next/image";
-import Script from "next/script";
 
 import { isMobile } from "react-device-detect"; // it's not ideal to use this, but it's a quick solution. Doesn't seem to have nice support for NextJs 13 yet though.
 
@@ -11,12 +10,10 @@ import { cx } from "class-variance-authority";
 
 // @todo handle public path better
 import NextLogo from "../../../../public/next-logo.svg";
+
 import ReactLogo from "../../../../public/react-logo.svg";
 import SvelteLogo from "../../../../public/svelte-logo.svg";
 import VueLogo from "../../../../public/vue-logo.svg";
-
-const SCROLL_TIMELINE_POLYFILL =
-  "https://flackr.github.io/scroll-timeline/dist/scroll-timeline.js";
 
 // @todo support getting images from CMS instead of defining them here
 const MAPPED_LOGOS = {
@@ -131,11 +128,11 @@ export const LogosGrid: React.FC = () => {
       )}
       ref={columnsRef}
     >
-      {/*This script isn't added globally, because it's only used by this component so far*/}
-      <Script src={SCROLL_TIMELINE_POLYFILL} />
       {LOGOS_KEYS.map((key, index) => (
         <Logo key={index} imageUrl={MAPPED_LOGOS[key].src} />
       ))}
     </div>
   );
 };
+
+export default LogosGrid;

--- a/packages/monogram-ui/src/components/animated/score/Score.tsx
+++ b/packages/monogram-ui/src/components/animated/score/Score.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import React, { useRef, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+
+import { useInView } from "react-intersection-observer";
 
 import { cx } from "class-variance-authority";
 
@@ -9,52 +11,32 @@ interface ScoreProps {
 }
 
 export const Score = ({ value }: ScoreProps) => {
-  const scoreRef = useRef<HTMLDivElement>(null);
+  const [inViewRef, inView] = useInView({ rootMargin: "0px 0px -10% 0px" });
   const [animatedValue, setAnimatedValue] = useState(0);
 
-  // I could use react-intersection-observer and make it look nicer, but this is the only place I'm using it, so I'm just using the native API
   useEffect(() => {
-    const handleAnimation = (
-      entries: IntersectionObserverEntry[],
-      observer: IntersectionObserver
-    ) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          let start: number | null = null;
+    if (inView) {
+      let start: number | null = null;
 
-          const animate = (timestamp: number) => {
-            if (start === null) start = timestamp;
-            const progress = timestamp - start;
-            const currentVal = (value * progress) / 1000;
+      const animate = (timestamp: number) => {
+        if (start === null) start = timestamp;
+        const progress = timestamp - start;
+        const currentVal = (value * progress) / 1000;
 
-            setAnimatedValue(currentVal > value ? value : currentVal);
+        setAnimatedValue(currentVal > value ? value : currentVal);
 
-            if (currentVal < value) {
-              requestAnimationFrame(animate);
-            }
-          };
-
+        if (currentVal < value) {
           requestAnimationFrame(animate);
-          observer.unobserve(entry.target);
         }
-      });
-    };
+      };
 
-    // We want to start animation slightly after the element is visible
-    const observer = new IntersectionObserver(handleAnimation, {
-      rootMargin: "0px 0px -10% 0px",
-    });
-
-    if (scoreRef.current) {
-      observer.observe(scoreRef.current);
+      requestAnimationFrame(animate);
     }
-
-    return () => observer.disconnect();
-  }, [value]);
+  }, [inView, value]);
 
   return (
     <div
-      ref={scoreRef}
+      ref={inViewRef}
       className="border-4 border-[#EFFFE2]/30 rounded-full drop-shadow-score aspect-square w-full h-full"
     >
       <div

--- a/packages/monogram-ui/src/components/animated/score/Score.tsx
+++ b/packages/monogram-ui/src/components/animated/score/Score.tsx
@@ -93,3 +93,5 @@ export const ScoreGrid = ({ className, scores }: ScoreGridProps) => (
     ))}
   </div>
 );
+
+export default ScoreGrid;

--- a/packages/monogram-ui/src/slices/footer/Footer.tsx
+++ b/packages/monogram-ui/src/slices/footer/Footer.tsx
@@ -1,4 +1,10 @@
-import { ScoreGrid, type ScoreGridProps, Text } from "../../components";
+import dynamic from "next/dynamic";
+
+import { type ScoreGridProps, Text } from "../../components";
+
+const DynamicScoreGrid = dynamic(
+  () => import("../../components/animated/score/Score")
+);
 
 type FooterProps = {
   scores: ScoreGridProps["scores"];
@@ -24,7 +30,7 @@ export const Footer = ({ scores, title, texts, footerNote }: FooterProps) => (
         >
           {title}
         </Text>
-        <ScoreGrid scores={scores} />
+        <DynamicScoreGrid scores={scores} />
         <div className="text-[#C7C7C7] mx-auto prose mt-10 sm:mt-16 lg:mt-24 opacity-50 mix-blend-color-dodge sm:max-w-xl lg:max-w-3xl">
           {texts.map((text, index) => (
             <Text key={index} size="md">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,7 @@ importers:
       react-device-detect: ^2.2.3
       react-dom: ^18.2.0
       react-error-boundary: ^3.1.4
+      react-intersection-observer: ^9.5.2
       storybook: ^7.1.1
       tailwindcss: ^3.3.2
       three: ^0.155.0
@@ -215,6 +216,7 @@ importers:
       next: 13.4.12_fe3dnxkyax5wguqewcrbc4wcza
       react-device-detect: 2.2.3_biqbaboplfbrettd7655fr4n2y
       react-error-boundary: 3.1.4_react@18.2.0
+      react-intersection-observer: 9.5.2_react@18.2.0
       three: 0.155.0
       utils: link:../utils
     devDependencies:
@@ -14619,6 +14621,14 @@ packages:
     dependencies:
       react: 18.2.0
     dev: true
+
+  /react-intersection-observer/9.5.2_react@18.2.0:
+    resolution: {integrity: sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}


### PR DESCRIPTION
## Updates:
- use react-intersection-observer package with footer and threeJS
- refactor threeJS component to use useFrame and render conditionally (if inView)
- import heavy client components dynamically
- tree-shake threeJS (by not including it ;))

## Top and Bottom Content sections:
### Mobile
<img width="956" alt="Screenshot 2023-08-04 at 23 03 00" 
src="https://github.com/yolodevz/resume/assets/96150994/a1b013c4-fd0b-45b1-9cc4-6adc987d2889">
### Desktop
<img width="954" alt="Screenshot 2023-08-04 at 23 03 06" src="https://github.com/yolodevz/resume/assets/96150994/06647962-8d4e-4b92-b90d-657893a0f35e">

---

## Blocks Section (and previous)
### Mobile
<img width="954" alt="Screenshot 2023-08-04 at 23 09 56" src="https://github.com/yolodevz/resume/assets/96150994/e49dfd22-eaa5-4e02-9afe-2572a70bcd55">

### Desktop
<img width="958" alt="Screenshot 2023-08-04 at 23 10 01" src="https://github.com/yolodevz/resume/assets/96150994/51cf808c-e520-40cb-a3a9-204966c1792e">

---

## Squiggly Divider Section (and previous)
### Mobile
<img width="949" alt="Screenshot 2023-08-04 at 23 20 29" src="https://github.com/yolodevz/resume/assets/96150994/bce63733-572c-45e2-9aac-6365297dbff2">

### Desktop
<img width="953" alt="Screenshot 2023-08-04 at 23 20 33" src="https://github.com/yolodevz/resume/assets/96150994/f47e8e36-b131-441e-ae49-81b3dfbdbd52">

---

## Computer Section (and previous)
### Mobile
<img width="947" alt="Screenshot 2023-08-04 at 23 25 12" src="https://github.com/yolodevz/resume/assets/96150994/a12147a8-8a27-4bf5-bcc8-0a370c982503">

### Desktop
<img width="953" alt="Screenshot 2023-08-04 at 23 25 17" src="https://github.com/yolodevz/resume/assets/96150994/2b0d3de5-3248-4483-a164-d8f845645680">

---

## Footer Section (and previous)
### Mobile
<img width="951" alt="Screenshot 2023-08-05 at 00 03 36" src="https://github.com/yolodevz/resume/assets/96150994/326e300c-1ccc-4e7a-b894-142513bbdc07">

### Desktop
<img width="955" alt="Screenshot 2023-08-05 at 00 03 40" src="https://github.com/yolodevz/resume/assets/96150994/778cfef3-8a4a-4268-a2f9-b1d785cebe3d">

---

## Logos Section (and previous) - **this component needs work**
note: performance test result ranges from 87 to 97
### Mobile
<img width="949" alt="Screenshot 2023-08-05 at 00 31 10" src="https://github.com/yolodevz/resume/assets/96150994/8a6ad363-3b61-4fba-b105-21201130f35b">

### Desktop
<img width="947" alt="Screenshot 2023-08-05 at 00 31 17" src="https://github.com/yolodevz/resume/assets/96150994/9ff28024-df3f-4467-b1b5-abcce26cc55d">

---

## Presentation Section (and previous) - **no visible improvement or decline**
### Mobile
<img width="954" alt="Screenshot 2023-08-05 at 00 40 01" src="https://github.com/yolodevz/resume/assets/96150994/0e6e856f-e1d1-4559-8d80-692bce3ae811">

### Desktop
<img width="953" alt="Screenshot 2023-08-05 at 00 40 06" src="https://github.com/yolodevz/resume/assets/96150994/bb19898f-bdd1-4f74-9d77-b09dd88189cc">

---

## Three JS Sphere included (and previous) - **huge improvement**
### Mobile
<img width="955" alt="Screenshot 2023-08-05 at 01 12 18" src="https://github.com/yolodevz/resume/assets/96150994/06e1754d-9235-498e-91e4-63bccab36856">

### Desktop
<img width="952" alt="Screenshot 2023-08-05 at 01 12 23" src="https://github.com/yolodevz/resume/assets/96150994/50b32525-e99a-4e12-b45d-8564425bbdaf">